### PR TITLE
Toggle isHima value based on Firestore document existence

### DIFF
--- a/my_web_app/lib/list.dart
+++ b/my_web_app/lib/list.dart
@@ -138,20 +138,21 @@ class _NextPageState extends State<NextPage> {
           },
         ),
         for (var person in himaPeople)
-          ListTile(
-            leading: const Icon(Icons.person),
-            title: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              children: <Widget>[
-                Text(person.name),
-                Text('~00:00'),
-                Text('テスト'),
-              ],
+          if (person.isHima)
+            ListTile(
+              leading: const Icon(Icons.person),
+              title: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: <Widget>[
+                  Text(person.name),
+                  Text('~00:00'),
+                  Text('テスト'),
+                ],
+              ),
+              onTap: () {
+                Navigator.pop(context);
+              },
             ),
-            onTap: () {
-              Navigator.pop(context);
-            },
-          ),
       ]
 
               //     ListTile(
@@ -200,6 +201,11 @@ class _NextPageState extends State<NextPage> {
           //     print('${doc.id}: ${doc.data()['id']}, ${doc.data()['name']}, ${doc.data()['isHima']}');
           //   }
           // });
+
+          // ログインできているか確認
+          bool isLogin = FirebaseAuth.instance.currentUser != null;
+
+          print('uid: $uid');
 
           // FirebaseFirestore.instance.collection("users").where("id", isEqualTo: uid).get()に該当するドキュメントがあるか否か判定
           final snapshot = await FirebaseFirestore.instance

--- a/my_web_app/lib/list.dart
+++ b/my_web_app/lib/list.dart
@@ -204,6 +204,12 @@ class _NextPageState extends State<NextPage> {
 
           // ログインできているか確認
           bool isLogin = FirebaseAuth.instance.currentUser != null;
+          print('isLogin: $isLogin');
+
+          // ログインしていなければログイン画面に遷移
+          if (!isLogin) {
+            Navigator.pop(context);
+          }
 
           print('uid: $uid');
 

--- a/my_web_app/lib/list.dart
+++ b/my_web_app/lib/list.dart
@@ -210,26 +210,20 @@ class _NextPageState extends State<NextPage> {
           HimaPeople newPerson;
 
           if (snapshot.docs.isEmpty) {
-            print('No such document!');
             newPerson = HimaPeople(id: '$uid', name: '$email', isHima: true);
+            await addHimaPerson(newPerson);
           } else {
-            print("snapshot.docs[0].id: ${snapshot.docs[0].id}");
-            print('Document data: ${snapshot.docs[0].data()}');
             // snapshot.docs[0].data()の中身のisHimaを取得
             bool isHima = snapshot.docs[0].data()['isHima'];
-            // snapshot.docs[0].data()を削除
+
+            // snapshot.docs[0]のisHimaを反転
             await FirebaseFirestore.instance
                 .collection("users")
                 .doc(snapshot.docs[0].id)
-                .delete();
-
-            print("isHima: $isHima");
-
-            newPerson = HimaPeople(id: '$uid', name: '$email', isHima: !isHima);
+                .update({'isHima': !isHima});
           }
 
           // Firestoreにデータを追加
-          await addHimaPerson(newPerson);
 
           // getHimaPeople();
           get();


### PR DESCRIPTION
This pull request includes changes to toggle the `isHima` value based on the existence of a Firestore document. The code now checks if the user is logged in and if a specific document exists in the Firestore collection. If the document exists, the `isHima` value is updated to its opposite value. If the document doesn't exist, a new document is created with the `isHima` value set to `true`.