### PR TITLE
Toggle isHima value based on Firestore document existence

### DIFF
--- a/my_web_app/lib/list.dart
+++ b/my_web_app/lib/list.dart
@@ -97,7 +97,7 @@ class _NextPageState extends State<NextPage> {
               title: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                 children: <Widget>[
-                  Text(person.name != Null ? person.name : person.mail),
+                  Text(person.name ?? person.mail),
                   Text('~00:00'),
                   Text('テスト'),
                 ],

--- a/my_web_app/lib/list.dart
+++ b/my_web_app/lib/list.dart
@@ -3,6 +3,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:my_web_app/model/himapeople.dart';
 import 'package:my_web_app/firebase/firestore.dart';
+import 'package:my_web_app/name_reg.dart';
 
 class NextPage extends StatefulWidget {
   const NextPage({super.key});
@@ -15,6 +16,7 @@ class _NextPageState extends State<NextPage> {
   List<HimaPeople> himapeopleSnapshot = [];
   List<HimaPeople> himaPeople = [];
   bool isLoading = false;
+  late String name;
 
   @override
   void initState() {
@@ -95,7 +97,7 @@ class _NextPageState extends State<NextPage> {
               title: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                 children: <Widget>[
-                  Text(person.name),
+                  Text(person.name? ),
                   Text('~00:00'),
                   Text('テスト'),
                 ],
@@ -173,7 +175,8 @@ class _NextPageState extends State<NextPage> {
           HimaPeople newPerson;
 
           if (snapshot.docs.isEmpty) {
-            newPerson = HimaPeople(id: '$uid', name: '$email', isHima: true);
+            newPerson = HimaPeople(
+                id: '$uid', mail: '$email', isHima: true, name: '$name');
             await addHimaPerson(newPerson);
           } else {
             // snapshot.docs[0].data()の中身のisHimaを取得

--- a/my_web_app/lib/list.dart
+++ b/my_web_app/lib/list.dart
@@ -97,7 +97,7 @@ class _NextPageState extends State<NextPage> {
               title: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                 children: <Widget>[
-                  Text(person.name? ),
+                  Text(person.name != Null ? person.name : person.mail),
                   Text('~00:00'),
                   Text('テスト'),
                 ],

--- a/my_web_app/lib/list.dart
+++ b/my_web_app/lib/list.dart
@@ -113,6 +113,9 @@ class _NextPageState extends State<NextPage> {
         ),
       ),
       floatingActionButton: FloatingActionButton.large(
+        backgroundColor: Colors.lightBlue, // Light blue color
+        elevation: 8.0,
+        shape: const CircleBorder(), // Ensures a perfect circle shape
         onPressed: () async {
           DateTime now = DateTime.now();
           String formattedTime = "${now.hour}:${now.minute}";
@@ -160,7 +163,7 @@ class _NextPageState extends State<NextPage> {
 
           get();
         },
-        child: Text(
+        child: const Text(
           '暇',
           style: TextStyle(
             fontSize: 36, // Increased font size
@@ -168,9 +171,6 @@ class _NextPageState extends State<NextPage> {
             color: Colors.white, // Ensures good contrast with the background
           ),
         ),
-        backgroundColor: Colors.lightBlue, // Light blue color
-        elevation: 8.0,
-        shape: CircleBorder(), // Ensures a perfect circle shape
       ),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       bottomNavigationBar: BottomNavigationBar(

--- a/my_web_app/lib/list.dart
+++ b/my_web_app/lib/list.dart
@@ -1,3 +1,4 @@
+import 'dart:ui';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
@@ -67,6 +68,14 @@ class _NextPageState extends State<NextPage> {
     });
   }
 
+  Future<void> _refresh() async {
+    // getHimaPeople();
+    await get();
+    return Future.delayed(
+      const Duration(milliseconds: 500),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -76,70 +85,86 @@ class _NextPageState extends State<NextPage> {
         backgroundColor: const Color(0xFF00FF00),
       ),
       body: Center(
-          child: ListView(children: <Widget>[
-        ListTile(
-          leading: const Icon(Icons.person),
-          title: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-            children: <Widget>[
-              const Text('Name'),
-              const Text('Deadline'),
-              const Text('Place'),
-            ],
+        child: ScrollConfiguration(
+          behavior: ScrollConfiguration.of(context).copyWith(
+            physics: const BouncingScrollPhysics(),
+            dragDevices: {
+              PointerDeviceKind.touch,
+              PointerDeviceKind.mouse,
+              PointerDeviceKind.trackpad
+            },
           ),
-          // onTap: () {
-          //   Navigator.pop(context);
-          // },
+          child: RefreshIndicator(
+            onRefresh: _refresh,
+            child: ListView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                children: [
+                  // ListTile(
+                  //   leading: const Icon(Icons.person),
+                  //   title: Row(
+                  //     mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  //     children: <Widget>[
+                  //       const Text('Name'),
+                  //       const Text('Deadline'),
+                  //       const Text('Place'),
+                  //     ],
+                  //   ),
+                  //   // onTap: () {
+                  //   //   Navigator.pop(context);
+                  //   // },
+                  // ),
+                  for (var person in himaPeople)
+                    if (person.isHima)
+                      ListTile(
+                        leading: const Icon(Icons.person),
+                        title: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                          children: <Widget>[
+                            Text(person.name ?? person.mail),
+                            Text('~00:00'),
+                            Text('テスト'),
+                          ],
+                        ),
+                        // onTap: () {
+                        //   Navigator.pop(context);
+                        // },
+                      ),
+                ]
+
+                //     ListTile(
+                //       leading: const Icon(Icons.person),
+                //       title: const Text('ひろと'),
+                //       subtitle: Row(children: <Widget>[
+                //         Text('12:00'),
+                //         SizedBox(width: 10),
+                //         Text('3学'),
+                //       ]),
+                //       onTap: () {
+                //         Navigator.pop(context);
+                //       },
+                //     ),
+                //     ListTile(
+                //       leading: const Icon(Icons.person),
+                //       title: const Text('いより'),
+                //       onTap: () {
+                //         Navigator.pop(context);
+                //       },
+                //     ),
+                //   ],
+                // ))
+
+                // body: Center(
+                //   child: ElevatedButton(
+                //     onPressed: () {
+                //       Navigator.pop(context);
+                //     },
+                //     child: const Text('Go back!'),
+                //   ),
+                // ),
+                ),
+          ),
         ),
-        for (var person in himaPeople)
-          if (person.isHima)
-            ListTile(
-              leading: const Icon(Icons.person),
-              title: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                children: <Widget>[
-                  Text(person.name ?? person.mail),
-                  Text('~00:00'),
-                  Text('テスト'),
-                ],
-              ),
-              // onTap: () {
-              //   Navigator.pop(context);
-              // },
-            ),
-      ]
-
-              //     ListTile(
-              //       leading: const Icon(Icons.person),
-              //       title: const Text('ひろと'),
-              //       subtitle: Row(children: <Widget>[
-              //         Text('12:00'),
-              //         SizedBox(width: 10),
-              //         Text('3学'),
-              //       ]),
-              //       onTap: () {
-              //         Navigator.pop(context);
-              //       },
-              //     ),
-              //     ListTile(
-              //       leading: const Icon(Icons.person),
-              //       title: const Text('いより'),
-              //       onTap: () {
-              //         Navigator.pop(context);
-              //       },
-              //     ),
-              //   ],
-              // ))
-
-              // body: Center(
-              //   child: ElevatedButton(
-              //     onPressed: () {
-              //       Navigator.pop(context);
-              //     },
-              //     child: const Text('Go back!'),
-              //   ),
-              // ),
-              )),
+      ),
       floatingActionButton: FloatingActionButton.large(
         onPressed: () async {
           // 例として新しいHimaPeopleオブジェクトを作成

--- a/my_web_app/lib/list.dart
+++ b/my_web_app/lib/list.dart
@@ -1,6 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:my_web_app/main.dart';
 import 'package:my_web_app/model/himapeople.dart';
 import 'package:my_web_app/firebase/firestore.dart';
 import 'package:my_web_app/name_reg.dart';
@@ -86,9 +87,9 @@ class _NextPageState extends State<NextPage> {
               const Text('Place'),
             ],
           ),
-          onTap: () {
-            Navigator.pop(context);
-          },
+          // onTap: () {
+          //   Navigator.pop(context);
+          // },
         ),
         for (var person in himaPeople)
           if (person.isHima)
@@ -102,9 +103,9 @@ class _NextPageState extends State<NextPage> {
                   Text('テスト'),
                 ],
               ),
-              onTap: () {
-                Navigator.pop(context);
-              },
+              // onTap: () {
+              //   Navigator.pop(context);
+              // },
             ),
       ]
 
@@ -161,7 +162,12 @@ class _NextPageState extends State<NextPage> {
 
           // ログインしていなければログイン画面に遷移
           if (!isLogin) {
-            Navigator.pop(context);
+            // Navigator.pop(context);
+            // MyHomePageに遷移
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (context) => const MyHomePage()),
+            );
           }
 
           print('uid: $uid');

--- a/my_web_app/lib/list.dart
+++ b/my_web_app/lib/list.dart
@@ -102,7 +102,7 @@ class _NextPageState extends State<NextPage> {
                         title: Row(
                           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                           children: <Widget>[
-                            Text(person.name ?? person.mail),
+                            Text(person.name ?? "No Name"),
                             Text('~00:00'),
                             Text('テスト'),
                           ],

--- a/my_web_app/lib/list.dart
+++ b/my_web_app/lib/list.dart
@@ -103,8 +103,8 @@ class _NextPageState extends State<NextPage> {
                           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                           children: <Widget>[
                             Text(person.name ?? "No Name"),
-                            Text('~00:00'),
-                            Text('テスト'),
+                            const Text('~00:00'),
+                            const Text('テスト'),
                           ],
                         ),
                       ),
@@ -145,7 +145,7 @@ class _NextPageState extends State<NextPage> {
 
           if (snapshot.docs.isEmpty) {
             newPerson = HimaPeople(
-                id: '$uid', mail: '$email', isHima: true, name: '$name');
+                id: '$uid', mail: '$email', isHima: true, name: name);
             await addHimaPerson(newPerson);
           } else {
             // snapshot.docs[0].data()の中身のisHimaを取得

--- a/my_web_app/lib/list.dart
+++ b/my_web_app/lib/list.dart
@@ -84,17 +84,17 @@ class _NextPageState extends State<NextPage> {
             child: ListView(
                 physics: const AlwaysScrollableScrollPhysics(),
                 children: [
-                  // ListTile(
-                  //   leading: const Icon(Icons.person),
-                  //   title: Row(
-                  //     mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                  //     children: <Widget>[
-                  //       const Text('Name'),
-                  //       const Text('Deadline'),
-                  //       const Text('Place'),
-                  //     ],
-                  //   ),
-                  // ),
+                  const ListTile(
+                    leading: Icon(Icons.person),
+                    title: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                      children: <Widget>[
+                        Text('Name'),
+                        Text('Deadline'),
+                        Text('Place'),
+                      ],
+                    ),
+                  ),
                   for (var person in himaPeople)
                     if (person.isHima)
                       ListTile(
@@ -127,7 +127,6 @@ class _NextPageState extends State<NextPage> {
 
           // ログインできているか確認
           bool isLogin = FirebaseAuth.instance.currentUser != null;
-          print('isLogin: $isLogin');
 
           // ログインしていなければログイン画面に遷移
           if (!isLogin) {
@@ -136,8 +135,6 @@ class _NextPageState extends State<NextPage> {
               MaterialPageRoute(builder: (context) => const MyHomePage()),
             );
           }
-
-          print('uid: $uid');
 
           final snapshot = await FirebaseFirestore.instance
               .collection("users")

--- a/my_web_app/lib/list.dart
+++ b/my_web_app/lib/list.dart
@@ -27,20 +27,6 @@ class _NextPageState extends State<NextPage> {
     get();
   }
 
-  // Future getHimaPeople() async {
-  //   setState(() => isLoading = true);
-  //   himapeopleSnapshot = await FirestoreHelper.instance.selectAllHimaPeople(
-  //       "Ian4IDN4ryYtbv9h4igNeUdZQkB3"); //←users配下のcatsコレクションのドキュメントを全件読み込む
-  //   himaPeople = himapeopleSnapshot //←受け取ったDocumentsnapshotの値をListに変換する
-  //       .map((doc) => HimaPeople(
-  //             id: doc['id'],
-  //             name: doc['name'],
-  //             isHima: doc['isHima'],
-  //           ))
-  //       .toList();
-  //   setState(() => isLoading = false);
-  // }
-
   Future getHimaPeople() async {
     setState(() => isLoading = true);
     himaPeople = await FirestoreHelper.instance
@@ -69,7 +55,6 @@ class _NextPageState extends State<NextPage> {
   }
 
   Future<void> _refresh() async {
-    // getHimaPeople();
     await get();
     return Future.delayed(
       const Duration(milliseconds: 500),
@@ -109,9 +94,6 @@ class _NextPageState extends State<NextPage> {
                   //       const Text('Place'),
                   //     ],
                   //   ),
-                  //   // onTap: () {
-                  //   //   Navigator.pop(context);
-                  //   // },
                   // ),
                   for (var person in himaPeople)
                     if (person.isHima)
@@ -125,61 +107,20 @@ class _NextPageState extends State<NextPage> {
                             Text('テスト'),
                           ],
                         ),
-                        // onTap: () {
-                        //   Navigator.pop(context);
-                        // },
                       ),
-                ]
-
-                //     ListTile(
-                //       leading: const Icon(Icons.person),
-                //       title: const Text('ひろと'),
-                //       subtitle: Row(children: <Widget>[
-                //         Text('12:00'),
-                //         SizedBox(width: 10),
-                //         Text('3学'),
-                //       ]),
-                //       onTap: () {
-                //         Navigator.pop(context);
-                //       },
-                //     ),
-                //     ListTile(
-                //       leading: const Icon(Icons.person),
-                //       title: const Text('いより'),
-                //       onTap: () {
-                //         Navigator.pop(context);
-                //       },
-                //     ),
-                //   ],
-                // ))
-
-                // body: Center(
-                //   child: ElevatedButton(
-                //     onPressed: () {
-                //       Navigator.pop(context);
-                //     },
-                //     child: const Text('Go back!'),
-                //   ),
-                // ),
-                ),
+                ]),
           ),
         ),
       ),
       floatingActionButton: FloatingActionButton.large(
         onPressed: () async {
-          // 例として新しいHimaPeopleオブジェクトを作成
           DateTime now = DateTime.now();
           String formattedTime = "${now.hour}:${now.minute}";
-          // ログインしている場合，ユーザーのemailを取得
+
+          // ユーザー情報を取得
           final user = FirebaseAuth.instance.currentUser;
           final uid = user?.uid;
           final email = user?.email;
-          // firestoreのusersコレクションの任意のドキュメントのコレクションの中のidにuser?.uidがあるか確認
-          // FirebaseFirestore.instance.collection("users").where("id", isEqualTo: uid).get().then((snapshot) {
-          //   for (var doc in snapshot.docs) {
-          //     print('${doc.id}: ${doc.data()['id']}, ${doc.data()['name']}, ${doc.data()['isHima']}');
-          //   }
-          // });
 
           // ログインできているか確認
           bool isLogin = FirebaseAuth.instance.currentUser != null;
@@ -187,8 +128,6 @@ class _NextPageState extends State<NextPage> {
 
           // ログインしていなければログイン画面に遷移
           if (!isLogin) {
-            // Navigator.pop(context);
-            // MyHomePageに遷移
             Navigator.push(
               context,
               MaterialPageRoute(builder: (context) => const MyHomePage()),
@@ -197,7 +136,6 @@ class _NextPageState extends State<NextPage> {
 
           print('uid: $uid');
 
-          // FirebaseFirestore.instance.collection("users").where("id", isEqualTo: uid).get()に該当するドキュメントがあるか否か判定
           final snapshot = await FirebaseFirestore.instance
               .collection("users")
               .where("id", isEqualTo: uid)
@@ -220,9 +158,6 @@ class _NextPageState extends State<NextPage> {
                 .update({'isHima': !isHima});
           }
 
-          // Firestoreにデータを追加
-
-          // getHimaPeople();
           get();
         },
         child: Text(

--- a/my_web_app/lib/login_page.dart
+++ b/my_web_app/lib/login_page.dart
@@ -80,7 +80,7 @@ class _LoginPageState extends State<LoginPage> {
                       );
                       // ユーザー登録に成功した場合
                       Navigator.push(context,
-                          MaterialPageRoute(builder: (context) => NextPage()));
+                          MaterialPageRoute(builder: (context) => const NextPage()));
                     } catch (e) {
                       // ユーザー登録に失敗した場合
                       setState(() {

--- a/my_web_app/lib/main.dart
+++ b/my_web_app/lib/main.dart
@@ -29,16 +29,16 @@ class MyApp extends StatelessWidget {
       // home: const MyHomePage(title: 'Flutter Demo Home Page'),
       // ログイン済みならNextPage、未ログインならMyHomePageを表示
       home: FirebaseAuth.instance.currentUser == null
-          ? const MyHomePage(title: 'Flutter Demo Home Page')
+          ? const MyHomePage()
           : const NextPage(),
     );
   }
 }
 
 class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
+  const MyHomePage({super.key});
 
-  final String title;
+  final String title = "ひマッチ";
 
   @override
   State<MyHomePage> createState() => _MyHomePageState();

--- a/my_web_app/lib/main.dart
+++ b/my_web_app/lib/main.dart
@@ -63,7 +63,7 @@ class _MyHomePageState extends State<MyHomePage> {
           ElevatedButton(
             onPressed: () {
               Navigator.push(context,
-                  MaterialPageRoute(builder: (context) => LoginPage()));
+                  MaterialPageRoute(builder: (context) => const LoginPage()));
             },
             style: ElevatedButton.styleFrom(
               backgroundColor: Colors.grey[300],
@@ -74,7 +74,7 @@ class _MyHomePageState extends State<MyHomePage> {
           ElevatedButton(
             onPressed: () {
               Navigator.push(context,
-                  MaterialPageRoute(builder: (context) => SignupPage()));
+                  MaterialPageRoute(builder: (context) => const SignupPage()));
             },
             style: ElevatedButton.styleFrom(
               backgroundColor: Colors.grey[300],

--- a/my_web_app/lib/main.dart
+++ b/my_web_app/lib/main.dart
@@ -26,7 +26,11 @@ class MyApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      // home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      // ログイン済みならNextPage、未ログインならMyHomePageを表示
+      home: FirebaseAuth.instance.currentUser == null
+          ? const MyHomePage(title: 'Flutter Demo Home Page')
+          : const NextPage(),
     );
   }
 }

--- a/my_web_app/lib/model/himapeople.dart
+++ b/my_web_app/lib/model/himapeople.dart
@@ -2,7 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 
 class HimaPeople {
   String id;
-  String name;
+  String? name;
   bool isHima;
   String mail;
 
@@ -16,10 +16,11 @@ class HimaPeople {
   factory HimaPeople.fromFirestore(DocumentSnapshot<Map<String, dynamic>> doc) {
     final data = doc.data()!;
     return HimaPeople(
-        id: data['id'],
-        name: data['name'],
-        isHima: data['isHima'],
-        mail: data['mail']);
+      id: data['id'] ?? "",
+      name: data['name'] ?? "",
+      isHima: data['isHima'] ?? false,
+      mail: data['mail'] ?? "",
+    );
   }
 
   Map<String, dynamic> toFirestore() {

--- a/my_web_app/lib/model/himapeople.dart
+++ b/my_web_app/lib/model/himapeople.dart
@@ -4,20 +4,22 @@ class HimaPeople {
   String id;
   String name;
   bool isHima;
+  String mail;
 
   HimaPeople({
     required this.id,
     required this.name,
     required this.isHima,
+    required this.mail,
   });
 
   factory HimaPeople.fromFirestore(DocumentSnapshot<Map<String, dynamic>> doc) {
     final data = doc.data()!;
     return HimaPeople(
-      id: data['id'],
-      name: data['name'],
-      isHima: data['isHima'],
-    );
+        id: data['id'],
+        name: data['name'],
+        isHima: data['isHima'],
+        mail: data['mail']);
   }
 
   Map<String, dynamic> toFirestore() {
@@ -25,6 +27,7 @@ class HimaPeople {
       "id": id,
       "name": name,
       "isHima": isHima,
+      "mail": mail,
     };
   }
 }

--- a/my_web_app/lib/name_reg.dart
+++ b/my_web_app/lib/name_reg.dart
@@ -1,0 +1,139 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:my_web_app/firebase/firestore.dart';
+import 'package:my_web_app/list.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:my_web_app/model/himapeople.dart';
+import 'package:my_web_app/signup_page.dart';
+import 'firebase_options.dart';
+import 'package:my_web_app/login_page.dart';
+
+class NameReg extends StatefulWidget {
+  const NameReg({super.key});
+
+  @override
+  State<NameReg> createState() => _NameRegState();
+}
+
+class _NameRegState extends State<NameReg> {
+  final myController = TextEditingController();
+  late String name;
+
+  List<HimaPeople> himapeopleSnapshot = [];
+  List<HimaPeople> himaPeople = [];
+  bool isLoading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    // getHimaPeople();
+    get();
+  }
+
+  Future getHimaPeople() async {
+    setState(() => isLoading = true);
+    himaPeople = await FirestoreHelper.instance
+        .selectAllHimaPeople("Ian4IDN4ryYtbv9h4igNeUdZQkB3");
+    setState(() => isLoading = false);
+  }
+
+  // usersコレクションのドキュメントを全件読み込む
+  Future get() async {
+    final snapshot = await FirebaseFirestore.instance.collection('users').get();
+    final himaPeople = snapshot.docs
+        .map((doc) => HimaPeople.fromFirestore(
+            doc as DocumentSnapshot<Map<String, dynamic>>))
+        .toList();
+    setState(() {
+      this.himaPeople = himaPeople;
+    });
+  }
+
+  Future<void> addHimaPerson(HimaPeople person) async {
+    await FirebaseFirestore.instance.collection('users').add({
+      'id': person.id,
+      'name': person.name,
+      'isHima': person.isHima,
+      'email': person.mail,
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('名前登録!!'),
+      ),
+      body: Container(
+        width: double.infinity,
+        child: Column(
+          children: [
+            TextField(
+              decoration: InputDecoration(
+                hintText: '名前',
+              ),
+              onChanged: (String value) {
+                setState(() {
+                  name = value;
+                });
+              },
+            ),
+            ElevatedButton(
+              child: Text('登録'),
+              onPressed: () async {
+                final user = FirebaseAuth.instance.currentUser;
+                final uid = user?.uid;
+                final email = user?.email;
+
+                // ログインできているか確認
+                bool isLogin = FirebaseAuth.instance.currentUser != null;
+                print('isLogin: $isLogin');
+
+                // ログインしていなければログイン画面に遷移
+                if (!isLogin) {
+                  Navigator.pop(context);
+                }
+
+                print('uid: $uid');
+
+                // FirebaseFirestore.instance.collection("users").where("id", isEqualTo: uid).get()に該当するドキュメントがあるか否か判定
+                final snapshot = await FirebaseFirestore.instance
+                    .collection("users")
+                    .where("id", isEqualTo: uid)
+                    .get();
+
+                HimaPeople newPerson;
+
+                if (snapshot.docs.isEmpty) {
+                  newPerson = HimaPeople(
+                      id: '$uid', mail: '$email', isHima: true, name: '$name');
+                  await addHimaPerson(newPerson);
+                } else {
+                  // snapshot.docs[0].data()の中身のisHimaを取得
+                  bool isHima = snapshot.docs[0].data()['isHima'];
+
+                  // snapshot.docs[0]のisHimaを反転
+                  await FirebaseFirestore.instance
+                      .collection("users")
+                      .doc(snapshot.docs[0].id)
+                      .update({'name': name});
+                }
+
+                // Firestoreにデータを追加
+
+                // getHimaPeople();
+                get();
+                Navigator.push(context,
+                    MaterialPageRoute(builder: (context) => NextPage()));
+// await Firestore.instance
+                // TODO: 新規登録
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/my_web_app/lib/name_reg.dart
+++ b/my_web_app/lib/name_reg.dart
@@ -64,14 +64,14 @@ class _NameRegState extends State<NameReg> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('名前登録!!'),
+        title: const Text('名前登録!!'),
       ),
       body: Container(
         width: double.infinity,
         child: Column(
           children: [
             TextField(
-              decoration: InputDecoration(
+              decoration: const InputDecoration(
                 hintText: '名前',
               ),
               onChanged: (String value) {
@@ -81,7 +81,7 @@ class _NameRegState extends State<NameReg> {
               },
             ),
             ElevatedButton(
-              child: Text('登録'),
+              child: const Text('登録'),
               onPressed: () async {
                 final user = FirebaseAuth.instance.currentUser;
                 final uid = user?.uid;
@@ -108,7 +108,7 @@ class _NameRegState extends State<NameReg> {
 
                 if (snapshot.docs.isEmpty) {
                   newPerson = HimaPeople(
-                      id: '$uid', mail: '$email', isHima: true, name: '$name');
+                      id: '$uid', mail: '$email', isHima: true, name: name);
                   await addHimaPerson(newPerson);
                 } else {
                   // snapshot.docs[0].data()の中身のisHimaを取得
@@ -126,7 +126,7 @@ class _NameRegState extends State<NameReg> {
                 // getHimaPeople();
                 get();
                 Navigator.push(context,
-                    MaterialPageRoute(builder: (context) => NextPage()));
+                    MaterialPageRoute(builder: (context) => const NextPage()));
 // await Firestore.instance
                 // TODO: 新規登録
               },

--- a/my_web_app/lib/name_reg.dart
+++ b/my_web_app/lib/name_reg.dart
@@ -66,7 +66,7 @@ class _NameRegState extends State<NameReg> {
       appBar: AppBar(
         title: const Text('名前登録!!'),
       ),
-      body: Container(
+      body: SizedBox(
         width: double.infinity,
         child: Column(
           children: [

--- a/my_web_app/lib/signup_page.dart
+++ b/my_web_app/lib/signup_page.dart
@@ -104,7 +104,7 @@ class _SignupPageState extends State<SignupPage> {
                         });
                       }
                       Navigator.push(context,
-                          MaterialPageRoute(builder: (context) => NameReg()));
+                          MaterialPageRoute(builder: (context) => const NameReg()));
                     } catch (e) {
                       // ユーザー登録に失敗した場合
                       setState(() {

--- a/my_web_app/lib/signup_page.dart
+++ b/my_web_app/lib/signup_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:my_web_app/list.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:my_web_app/name_reg.dart';
 import 'firebase_options.dart';
 import 'package:my_web_app/login_page.dart';
 // class LoginSample extends StatelessWidget {
@@ -61,6 +62,16 @@ class _SignupPageState extends State<SignupPage> {
                   });
                 },
               ),
+              // // 名前
+              // TextFormField(
+              //   decoration: const InputDecoration(labelText: '名前'),
+              //   obscureText: true,
+              //   onChanged: (String value) {
+              //     setState(() {
+              //       password = value;
+              //     });
+              //   },
+              // ),
 
               Container(
                 padding: const EdgeInsets.all(8),
@@ -92,6 +103,8 @@ class _SignupPageState extends State<SignupPage> {
                           infoText = "確認メールを送信しました。メールを確認してください。";
                         });
                       }
+                      Navigator.push(context,
+                          MaterialPageRoute(builder: (context) => NameReg()));
                     } catch (e) {
                       // ユーザー登録に失敗した場合
                       setState(() {


### PR DESCRIPTION
This pull request includes several commits that refactor the home page initialization logic and fix null checks in the `list.dart` and `himapeople.dart` files. Additionally, the `isHima` value is now toggled based on the existence of a Firestore document. The `name_reg.dart` file has also been refactored to replace a container with a `SizedBox`.